### PR TITLE
Refactoring text utils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     compile group: 'com.rometools', name: 'rome', version: '1.15.0'
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: '2.11.3'
+
+    implementation 'org.apache.commons:commons-lang3:3.11'
+
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.4.2'
 }
 

--- a/src/main/java/org/telegram/bot/utils/TextUtils.java
+++ b/src/main/java/org/telegram/bot/utils/TextUtils.java
@@ -1,10 +1,9 @@
 package org.telegram.bot.utils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.telegram.bot.domain.entities.User;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class TextUtils {
 
@@ -15,18 +14,10 @@ public class TextUtils {
      * @return potential command without rest text.
      */
     public static String getPotentialCommandInText(String text) {
-        if (text.charAt(0) == '/') {
-            text = text.substring(1);
-        }
-        Pattern pattern = Pattern.compile("^[a-zA-Zа-яА-Я0-9Ёё]+", Pattern.UNICODE_CHARACTER_CLASS);
-        Matcher matcher = pattern.matcher(text);
-        if (matcher.find()) {
-            String buf = matcher.group(0).trim();
-            pattern = Pattern.compile("\\W$", Pattern.UNICODE_CHARACTER_CLASS);
-            matcher = pattern.matcher(buf);
-            if (matcher.find()) {
-                return buf.substring(0, buf.length() - 1).toLowerCase();
-            }
+        String buf = StringUtils.substringBefore(text.trim(), " ")
+                .replaceAll("[^a-zA-Zа-яА-Я0-9Ёё]", "");
+
+        if (!StringUtils.isBlank(buf)) {
             return buf.toLowerCase();
         }
 
@@ -34,7 +25,7 @@ public class TextUtils {
     }
 
     public static String cutMarkdownSymbolsInText(String text) {
-        return text.replaceAll("[*_`\\[\\]()]", "").replaceAll("<.*?>","");
+        return text.replaceAll("[*_`\\[\\]()]", "").replaceAll("<[^>]*+>", "");
     }
 
     public static String reduceSpaces(String text) {
@@ -42,14 +33,14 @@ public class TextUtils {
             text = text.replaceAll(" +", " ");
         }
         while (text.contains("\n\n")) {
-            text = text.replaceAll("\n\n", "\n");
+            text = text.replace("\n\n", "\n");
         }
 
         return text.trim();
     }
 
     public static String cutHtmlTags(String text) {
-        return text.replaceAll("<.*?>","");
+        return text.replaceAll("<[^>]*+>", "");
     }
 
     public static String withCapital(String text) {

--- a/src/test/java/org/telegram/bot/utils/TextUtilsTest.java
+++ b/src/test/java/org/telegram/bot/utils/TextUtilsTest.java
@@ -2,7 +2,7 @@ package org.telegram.bot.utils;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.telegram.bot.utils.TextUtils.*;
 
 class TextUtilsTest {
@@ -17,23 +17,27 @@ class TextUtilsTest {
     @Test
     void getPotentialCommandInTextTest() {
         String textWithSlash = "/bot";
+        String textWithSlashAndCyphers = "/bot432bot432 rgeg";
         String textRussian = "Бот, как дела";
         String commonText = "погода Ростов-на-Дону";
+        String commonTextWithCyphers = "погода3 Ростов-на-Дону";
 
-        assertEquals(getPotentialCommandInText(textWithSlash), "bot");
-        assertEquals(getPotentialCommandInText(textRussian), "бот");
-        assertEquals(getPotentialCommandInText(commonText), "погода");
+        assertEquals("bot", getPotentialCommandInText(textWithSlash));
+        assertEquals("bot432bot432", getPotentialCommandInText(textWithSlashAndCyphers));
+        assertEquals("бот", getPotentialCommandInText(textRussian));
+        assertEquals("погода", getPotentialCommandInText(commonText));
+        assertEquals("погода3", getPotentialCommandInText(commonTextWithCyphers));
     }
 
     @Test
     void cutMarkdownSymbolsInTextTest() {
         String text = "*test1* _test2_ `test3` [test4](test5)";
-        assertEquals(cutMarkdownSymbolsInText(text), "test1 test2 test3 test4test5");
+        assertEquals("test1 test2 test3 test4test5", cutMarkdownSymbolsInText(text));
     }
 
     @Test
     void cutHtmlTagsTest() {
         String text = "<a href=\"example.com\">test</a>";
-        assertEquals(cutHtmlTags(text), "test");
+        assertEquals("test", cutHtmlTags(text));
     }
 }


### PR DESCRIPTION
Command parse simplifying; 
potential regexp vulnerability fix in `TextUtils#cutHtmlTags` and `TextUtils#cutMarkdownSymbolsInText` methods (https://rules.sonarsource.com/java/RSPEC-5857)
